### PR TITLE
Layout tweaks

### DIFF
--- a/CommunicationService/CommunicationService.SendGridManagement/Emails/Layout.html
+++ b/CommunicationService/CommunicationService.SendGridManagement/Emails/Layout.html
@@ -116,7 +116,7 @@
             <table align='center' border='0' cellpadding='0' cellspacing='0' role='presentation' style='background:#ffff;background-color:#ffff;width:100%;'>
                 <tr>
                     <td style='direction:ltr;font-size:0px;padding:0px 0px 9px 0px;text-align:center;vertical-align:top;'>
-                        <img height='auto' src='https://www.helpmystreet.org/img/logos/HelpMyStreet_Logo_1154.jpg' alt='HelpMyStreet.org logo' style='border:0;display:block;outline:none;height:auto;width:100%;' width='600'>
+                        <img src='https://www.helpmystreet.org/img/logos/HelpMyStreet_Logo_1154.jpg' alt='HelpMyStreet.org logo' style='border:0;display:block;outline:none;height:auto;width:100%;' width='600' height='136'>
                     </td>
                 </tr>
                 <tr>

--- a/CommunicationService/CommunicationService.SendGridManagement/Emails/TaskUpdateSimplified.html
+++ b/CommunicationService/CommunicationService.SendGridManagement/Emails/TaskUpdateSimplified.html
@@ -6,6 +6,8 @@
 <p>To view the request on our website, <a href='{{{JobUrl}}}'>click here</a>.</p>
 {{/if}}
 
+<br />
+
 <table class="taskdetails">
     {{#each ImportantDataList}}
     <tr>
@@ -21,6 +23,7 @@
     </tr>
     {{/each}}
 </table>
+
 <br />
 
 {{#if FaceCoveringComplete}}

--- a/CommunicationService/CommunicationService.SendGridManagement/Migrations/20201223_152600_NewSimplifiedUpdateTaskMessage.json
+++ b/CommunicationService/CommunicationService.SendGridManagement/Migrations/20201223_152600_NewSimplifiedUpdateTaskMessage.json
@@ -1,0 +1,15 @@
+﻿{
+  "Templates": [
+    {
+      "name": "TaskUpdateSimplified",
+      "subject": "{{{Subject}}}",
+      "generation": "dynamic",
+      "versions": [
+        {
+          "name": "Seventh Draft",
+          "subject": "{{{Subject}}}"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adding space before table in Task Update email.

Specifying height of header logo image, to prevent email clients displaying a 600x600px placeholder before images are downloaded.

**I'm not sure if additional migrations need to be added to apply the second change to all emails.**